### PR TITLE
Update VSInstall to install with elevated permissions

### DIFF
--- a/DSCResources/MSFT_VSInstall/MSFT_VSInstall.psm1
+++ b/DSCResources/MSFT_VSInstall/MSFT_VSInstall.psm1
@@ -94,7 +94,7 @@ function Set-TargetResource
             $workloadArgs += " --add $workload"
         }
         Write-Verbose -Message "Installing Visual Studio 2017"
-        Start-Process -FilePath $ExecutablePath -ArgumentList ("--quiet" + $workloadArgs) -Wait -PassThru -Credential $InstallAccount
+        Start-Process -FilePath $ExecutablePath -ArgumentList ("--quiet" + $workloadArgs) -Wait -PassThru -Verb runAs
 
         #Remove-Item -Path $tempFolder -Force -Recurse -Confirm:$false
     }


### PR DESCRIPTION
Was running into the following error in my installation:
"This command cannot be run due to the error: The requested operation requires elevation."

I removed the -credential option in line 97 and replaced it with -Verb runAs and it runs as the setup account (which I specified in my DSC config) without error in an "Run As Administrator" window.